### PR TITLE
(#175) Update light.py

### DIFF
--- a/custom_components/dobiss/light.py
+++ b/custom_components/dobiss/light.py
@@ -5,8 +5,8 @@ from dobissapi import DobissAnalogOutput, DobissLight, DobissOutput
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
-    SUPPORT_BRIGHTNESS,
     LightEntity,
+    LightEntityFeature,
 )
 from homeassistant.const import ATTR_ENTITY_ID, ENTITY_MATCH_ALL, ENTITY_MATCH_NONE
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -136,9 +136,9 @@ class HADobissLight(LightEntity):
     @property
     def supported_features(self):
         """Flag supported features."""
-        supports = 0
+        supports = LightEntityFeature(0)
         if self._dobisslight.dimmable:
-            supports = SUPPORT_BRIGHTNESS
+            supports = LightEntityFeature.BRIGHTNESS
         return supports
 
     @property


### PR DESCRIPTION
Hey, 

I tried to fix the lights as requested in #175 .
Based on the previous comits, climate and cover are already changed. 

I believe this should work for 2025.1. The following error is not looked at: 
"None (<class 'custom_components.dobiss.light.HADobissLight'>) does not set supported color modes, this will stop working in Home Assistant Core 2025.3, please create a bug report at https://github.com/kesteraernoudt/dobiss/issues"

Lights can turn on and off. But I updated dobiss today as well, and have some problems there and can't see the status of my lights. But I believe that is another problem unrelated to this. 

Kind regards,
Toon
